### PR TITLE
Add browser field and simple browser file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,15 @@ Note: Unicode may be handled incorrectly (like the browser).
 
 It turns base64-encoded <strong>a</strong>scii data back **to** <strong>b</strong>inary.
 
-    (function () {
-      "use strict";
-      
-      var atob = require('atob')
-        , b64 = "SGVsbG8gV29ybGQ="
-        , bin = atob(b64)
-        ;
+```js
+"use strict";
+var atob = require('atob')
+  , b64 = "SGVsbG8gV29ybGQ="
+  , bin = atob(b64)
+  ;
 
-      console.log(bin); // "Hello World"
-    }());
+console.log(bin); // "Hello World"
+```
 
 Copyright and license
 ===

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = window.atob;

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-(function () {
-  "use strict";
+'use strict';
 
-  function atob(str) {
-    return new Buffer(str, 'base64').toString('binary');
-  }
+function atob(str) {
+  return new Buffer(str, 'base64').toString('binary');
+}
 
-  module.exports = atob;
-}());
+module.exports = atob;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "git://github.com/coolaj86/node-browser-compat.git"
   },
+  "browser": "./browser.js",
+  "scripts": {
+    "test": "tape test.js"
+  },
   "keywords": [
     "atob",
     "browser"
@@ -19,5 +23,8 @@
     "atob": "bin/atob.js"
   },
   "license": "Apache2",
-  "version": "1.1.2"
+  "version": "1.1.2",
+  "devDependencies": {
+    "tape": "^4.2.0"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -1,20 +1,12 @@
 /*jshint strict:true node:true es5:true onevar:true laxcomma:true laxbreak:true eqeqeq:true immed:true latedef:true*/
-(function () {
-  "use strict";
+'use strict';
 
-  var atob = require('./index')
-    , encoded = "SGVsbG8gV29ybGQ="
-    , unencoded = "Hello World"
-  /*
-    , encoded = "SGVsbG8sIBZM"
-    , unencoded = "Hello, 世界"
-  */
-    ;
+var test = require('tape')
+  , atob = require('./')
+  ;
 
-  if (unencoded !== atob(encoded)) {
-    console.log('[FAIL]', unencoded, atob(encoded));
-    return;
-  }
-
-  console.log('[PASS] all tests pass');
-}());
+test('atob', function(t) {
+  t.equal('Hello World', atob('SGVsbG8gV29ybGQ='), 'base64-encodes string');
+  t.equal('', atob(''), 'base64-encodes empty string');
+  t.end();
+});


### PR DESCRIPTION
Also
- Turns tests into TAP-emitting tests that run on npm test
- Removes unnecessary iife
- Adds JS highlighting in readme
