### PR TITLE
Fix atob under CommonJS module bundlers (eg. Browserify)

### DIFF
--- a/browser-atob.js
+++ b/browser-atob.js
@@ -6,7 +6,7 @@
   function atob(str) {
     // normal window
     if ('function' === typeof a2b) {
-      return a2b(a2b);
+      return a2b(str);
     }
     // browserify (web worker)
     else if ('function' === typeof Buffer) {
@@ -29,4 +29,8 @@
   }
 
   w.atob = atob;
+
+  if (typeof module !== 'undefined') {
+    module.exports = atob;
+  }
 }(window));

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@
 (function () {
   "use strict";
 
-  var atob = require('./index')
+  var atob = require('.')
     , encoded = "SGVsbG8gV29ybGQ="
     , unencoded = "Hello World"
   /*


### PR DESCRIPTION
Browserify uses the browser version of the module but since
module.exports was not assigned, importing it fails.
- Fix a typo in the browser implementation of 'browser-atob'
- Fix reference to the source file in the tests. I ran these manually in the browser and Node but I'd suggest setting up Travis or similar.
- Export 'atob' implementation in 'browser-atob.js' via module
  exports
