### PR TITLE
Fix for browsers supporting a2b

### DIFF
--- a/browser-atob.js
+++ b/browser-atob.js
@@ -6,7 +6,7 @@
   function atob(str) {
     // normal window
     if ('function' === typeof a2b) {
-      return a2b(a2b);
+      return a2b(str);
     }
     // browserify (web worker)
     else if ('function' === typeof Buffer) {


### PR DESCRIPTION
Argument passed to a2b should be the ascii string.
